### PR TITLE
feat(network): 添加 use_stream 配置项以支持 SSE 流式请求

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -85,6 +85,12 @@
         "hint": "API 请求和图片下载的最大等待时间。",
         "default": 120
     },
+    "use_stream": {
+        "description": "【网络】启用流式请求（仅generic模式）",
+        "type": "bool",
+        "hint": "开启后使用SSE流式请求，避免Cloudflare 100秒超时限制（524错误）。推荐开启，仅对generic模式生效。",
+        "default": false
+    },
     "download_retries": {
         "description": "【网络】图片下载重试次数",
         "type": "int",


### PR DESCRIPTION
设定的API提供商(我自己)使用了非企业版的cloudflare cdn有100秒的超时限制，默认非流模式情况下经常在120秒左右报http code 524错误。
新增 `use_stream` 配置选项，允许用户启用或禁用流式 API 请求。该功能主要用于
generic 模式下，通过使用 Server-Sent Events (SSE) 来避免 Cloudflare 的 100 秒超时 限制（524 错误）。默认值为 false。

在 main.py 中，根据配置动态设置请求 payload 的 stream 参数，并增加对流式响应的 处理逻辑。当启用流式传输时，逐行读取并解析返回的数据块，最终构造完整的回复内容。
同时保留了非流式模式的兼容性。
<img width="1431" height="414" alt="image" src="https://github.com/user-attachments/assets/10a1bdf0-19e8-4557-bd88-a8c0f138ca6d" />
