### PR TITLE
增强模式支持群次数回退开关 + 次数耗尽时追加签到提醒

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -112,6 +112,12 @@
         "hint": "开启强力模式时除了基础扣费外额外扣除的次数，至少为0。",
         "default": 1
     },
+    "power_mode_fallback_to_group": {
+        "description": "【高级】强力模式群次数回退",
+        "type": "bool",
+        "hint": "开启后：强力模式优先扣个人次数；若个人次数不足且已启用群组次数限制，则顺位扣群次数。",
+        "default": false
+    },
     "power_generic_api_url": {
         "description": "【强力模式-Generic】API地址",
         "type": "string",

--- a/main.py
+++ b/main.py
@@ -978,13 +978,24 @@ class FigurineProPlugin(Star):
 
         if deduction_source is None:
             if use_power_model:
+                allow_group_fallback = bool(self.conf.get("power_mode_fallback_to_group", False))
                 if self.conf.get("enable_user_limit", True):
                     u_cnt = self._get_user_count(sender_id)
                     if u_cnt >= required_cost:
                         deduction_source = 'user'
                     else:
-                        yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
-                        return
+                        if allow_group_fallback and group_id and self.conf.get("enable_group_limit", False):
+                            g_cnt = self._get_group_count(group_id)
+                            if g_cnt >= required_cost:
+                                deduction_source = 'group'
+                            else:
+                                yield event.plain_result(
+                                    f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
+                                )
+                                return
+                        else:
+                            yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
+                            return
                 else:
                     deduction_source = 'free'
             else:
@@ -1219,13 +1230,24 @@ class FigurineProPlugin(Star):
             deduction_source = 'free'
         else:
             if use_power_model:
+                allow_group_fallback = bool(self.conf.get("power_mode_fallback_to_group", False))
                 if self.conf.get("enable_user_limit", True):
                     u_cnt = self._get_user_count(sender_id)
                     if u_cnt >= required_cost:
                         deduction_source = 'user'
                     else:
-                        yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
-                        return
+                        if allow_group_fallback and group_id and self.conf.get("enable_group_limit", False):
+                            g_cnt = self._get_group_count(group_id)
+                            if g_cnt >= required_cost:
+                                deduction_source = 'group'
+                            else:
+                                yield event.plain_result(
+                                    f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
+                                )
+                                return
+                        else:
+                            yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
+                            return
                 else:
                     deduction_source = 'free'
             else:

--- a/main.py
+++ b/main.py
@@ -568,7 +568,7 @@ class FigurineProPlugin(Star):
             msg += f"\n⚙️ 强力模式每次额外扣除 {extra_cost} 次。"
 
         if self.conf.get("enable_checkin", False) and self.conf.get("enable_user_limit", True):
-            msg += "\n📅 发送 \"手办化签到\" 指令（请按当前命令前缀或唤醒方式触发）可补充个人次数。"
+            msg += "\n📅 可发送 \"#手办化签到\" 获取次数（触发前缀/唤醒请按实际配置调整）。"
 
         return msg
 
@@ -989,12 +989,16 @@ class FigurineProPlugin(Star):
                             if g_cnt >= required_cost:
                                 deduction_source = 'group'
                             else:
-                                yield event.plain_result(
-                                    f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
-                                )
+                                msg = f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
+                                if self.conf.get("enable_checkin", False) and self.conf.get("enable_user_limit", True):
+                                    msg += "\n📅 可发送 \"#手办化签到\" 获取次数（触发前缀/唤醒请按实际配置调整）。"
+                                yield event.plain_result(msg)
                                 return
                         else:
-                            yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
+                            msg = f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。"
+                            if self.conf.get("enable_checkin", False) and self.conf.get("enable_user_limit", True):
+                                msg += "\n📅 可发送 \"#手办化签到\" 获取次数（触发前缀/唤醒请按实际配置调整）。"
+                            yield event.plain_result(msg)
                             return
                 else:
                     deduction_source = 'free'
@@ -1241,12 +1245,16 @@ class FigurineProPlugin(Star):
                             if g_cnt >= required_cost:
                                 deduction_source = 'group'
                             else:
-                                yield event.plain_result(
-                                    f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
-                                )
+                                msg = f"❌ 次数不足。需要 {required_cost} 次。\n👤 用户剩余: {u_cnt}\n👥 本群剩余: {g_cnt}"
+                                if self.conf.get("enable_checkin", False) and self.conf.get("enable_user_limit", True):
+                                    msg += "\n📅 可发送 \"#手办化签到\" 获取次数（触发前缀/唤醒请按实际配置调整）。"
+                                yield event.plain_result(msg)
                                 return
                         else:
-                            yield event.plain_result(f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。")
+                            msg = f"❌ 个人次数不足。需要 {required_cost} 次，当前剩余 {u_cnt} 次。"
+                            if self.conf.get("enable_checkin", False) and self.conf.get("enable_user_limit", True):
+                                msg += "\n📅 可发送 \"#手办化签到\" 获取次数（触发前缀/唤醒请按实际配置调整）。"
+                            yield event.plain_result(msg)
                             return
                 else:
                     deduction_source = 'free'


### PR DESCRIPTION
本次变更解决“增强模式无法使用群聊次数”的使用诉求，但保持默认行为不变。

新增配置开关：power_mode_fallback_to_group（默认关闭）
开启后，增强/强力模式扣费规则变为：
优先扣个人次数
若个人次数不足，且已开启群次数限制(enable_group_limit=true)且在群聊内，则顺位扣群次数
关闭时维持原逻辑：增强模式只使用个人次数（管理员/白名单免费逻辑不变）。
次数耗尽提示追加签到提醒
当 enable_checkin=true 且启用个人次数限制(enable_user_limit=true)时：
在“次数不足/次数耗尽”的报错末尾追加提示：可发送“#手办化签到”获取次数（前缀/唤醒方式请按实际配置调整）。
覆盖普通模式与增强模式（含个人不足、个人+群都不足等分支）。
变更文件：
main.py
_conf_schema.json

兼容性说明：
新增配置项默认关闭，不影响现有部署行为；仅在手动开启后改变增强模式扣费策略。

自测建议：

开启 enable_checkin，制造个人次数不足，确认报错带签到提醒
开启 enable_group_limit + power_mode_fallback_to_group，在群内个人不足但群次数足够，确认增强模式可扣群次数并正常生成
关闭 power_mode_fallback_to_group，确认增强模式仍只扣个人次数